### PR TITLE
Fix ukui-menu dependence missing when generate .qm file

### DIFF
--- a/ukui-menu/Makefile
+++ b/ukui-menu/Makefile
@@ -12,7 +12,7 @@ docker-build:
 
 deps:
 	@echo ">> install dependencies"
-	dnf install -y which gcc gcc-c++ make cmake cmake-rpm-macros autoconf automake intltool rpm-build qt5-rpm-macros   qt5-qtbase-devel qt5-qtsvg-devel qt5-qtx11extras-devel glib2-devel gsettings-qt-devel bamf-devel libXrandr-devel libXtst-devel libX11-devel
+	dnf install -y which gcc gcc-c++ make cmake cmake-rpm-macros autoconf automake intltool rpm-build qt5-rpm-macros   qt5-qtbase-devel qt5-qtsvg-devel qt5-qtx11extras-devel glib2-devel gsettings-qt-devel bamf-devel libXrandr-devel libXtst-devel libX11-devel qt5-linguist
 	strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so.5
 
 download-source:


### PR DESCRIPTION
`/usr/lib64/qt5/bin/lrelease` is missing when qmake genrate qm file, install qt5-linguist to fix it .
```
make: /../lib64/qt5/bin/lrelease: Command not found
/../lib64/qt5/bin/lrelease ../translations/ukui-menu_bo.ts -qm .qm/ukui-menu_bo.qm
make: *** [Makefile:560: .qm/ukui-menu_bo.qm] Error 127
```